### PR TITLE
fix log.Printf() args

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func httpGet(reqUrl url.URL, thread, counter, total int) {
 	resp.Body.Close()
 	end := time.Now()
 	if opts.Trace >= 3 {
-		log.Printf("[%03d-%05d] DEBUG response header: %#v, %s\n", thread, counter, reads, resp.Header, urlStr)
+		log.Printf("[%03d-%05d] DEBUG response header: %#v, %s\n", thread, counter, resp.Header, urlStr)
 	}
 	diff := end.Sub(start).Milliseconds()
 	if diff > int64(opts.ShowThresholdMs) {


### PR DESCRIPTION
```
main.go:77:3: printf: log.Printf call needs 4 args but has 5 args (govet)
                log.Printf("[%03d-%05d] DEBUG response header: %#v, %s\n", thread, counter, reads, resp.Header, urlStr)
```