### PR TITLE
Add minimumReleaseAge to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
## Summary

- `minimumReleaseAge: "7 days"` を追加し、リリースから7日経過していない依存関係の PR が作成されないようにした

## Test plan

- [ ] Renovate が次回実行されたとき、7日未満のリリースに対して PR が作成されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)