### PR TITLE
Rename GitHub App vars and fix tagpr trigger branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.HOMEBREW_APP_ID }}
+          client-id: ${{ vars.HOMEBREW_APP_ID }}
           private-key: ${{ secrets.HOMEBREW_APP_PRIVATE_KEY }}
           # 自分のリポジトリと Tap リポジトリの両方に権限を絞る（任意）
           owner: ${{ github.repository_owner }}

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -3,7 +3,7 @@ name: tagpr
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   tagpr:
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TAGPR_APP_ID }}
+          private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## 変更内容

- `.github/workflows/tagpr.yaml`
  - `vars.APP_ID` → `vars.TAGPR_APP_ID`
  - `secrets.APP_PRIVATE_KEY` → `secrets.TAGPR_APP_PRIVATE_KEY`
  - push トリガーのブランチを `master` → `main` に修正（デフォルトブランチは `main` のため、これまで発火していなかった）
- `.github/workflows/release.yaml`
  - `secrets.HOMEBREW_APP_ID` → `vars.HOMEBREW_APP_ID`（App ID は秘匿情報ではないため variable へ）

## 注意

マージ前にリポジトリ設定側で以下を用意する必要があります。

- Variables: `TAGPR_APP_ID`, `HOMEBREW_APP_ID`
- Secrets: `TAGPR_APP_PRIVATE_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6zqqEKNjQsZL1hLdEJgWk